### PR TITLE
Fix duplicate search result bug

### DIFF
--- a/js/dbAdapter.js
+++ b/js/dbAdapter.js
@@ -22,11 +22,12 @@ exports.find = (string, options) => new Promise((resolve, reject) => {
             results.push(recipe)
         }
         else if (options === undefined || options.ingredients === true) {
-            recipe.ingredients.forEach((ingredient) => {
+            for (let ingredient of recipe.ingredients) {
                 if (ingredient.name.indexOf(string) !== -1) {
                     results.push(recipe)
+                    break
                 }
-            })
+            }
         }
     })
     resolve(results)

--- a/routes/recipe.js
+++ b/routes/recipe.js
@@ -10,7 +10,6 @@ router.get('/', (req, res) => {
 router.get('/:recipeTitle', (req, res) => {
     var options = {ingredients:false, title: true}
     var term = req.params.recipeTitle
-    console.log(term)
     db.find(term, options)
         .then((results) => {
             var recipe = (results.length > 0 ? results[0] : null)


### PR DESCRIPTION
The issue was caused by using results.forEach() over the ingredients of
a recipe in dbAdapter.js and not being able to exit early from the
iteration of the elements. Resolved by using for...of and break.