### PR TITLE
Change ingredient filter to positive filter instead of negative

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -224,7 +224,7 @@ function filterTable(val) {
 
 	for (var key in pantry) {
 		const item = pantry[key]
-		if (val !== '' && item.name.indexOf(val) !== -1) {
+		if (val !== '' && item.name.indexOf(val) === -1) {
 			continue
 		}
 


### PR DESCRIPTION
For example, typing `a` would result in all ingredients _with_ `a`
instead of filtering out ingredients with `a`.