### PR TITLE
Fix MIME mismatch for ingredientInput.js

### DIFF
--- a/views/appScripts.pug
+++ b/views/appScripts.pug
@@ -1,4 +1,3 @@
-script(src=jsURL + '/app.js')
-script(src=jsURL + '/editRecipe.js')
-script(src=jsURL + '/ingredientInput.js')
-script(src=jsURL + '/recipeForm.js')
+script(type='application/javascript' src=jsURL + '/app.js')
+script(type='application/javascript' src=jsURL + '/editRecipe.js')
+script(type='application/javascript' src=jsURL + '/recipeForm.js')


### PR DESCRIPTION
Delete script resource in client page for ingredientInput.js because
file was deleted in 3a1b66d9.

Closes #131