### PR TITLE
Make fileDB and DB result filtering case-insensitive

### DIFF
--- a/dbAdapters/file.js
+++ b/dbAdapters/file.js
@@ -38,27 +38,37 @@ fs.readFile(config.options.localDB.options.filePath, 'utf8', (err, contents) => 
 	loaded = true
 })
 
-exports.find = (string, options) => new Promise((resolve, reject) => {
+exports.find = (term, options) => new Promise((resolve, reject) => {
 	if (!loaded) {
 		return reject(NOT_LOADED_MSG)
 	}
 
+	term = term.toLowerCase()
 	options = util.fillMissingOpts(options, defaultSearchOpts)
 	const results = []
 	for (const key in data.recipes) {
 		const recipe = data.recipes[key]
-		if (options.title === true
-			&& ((options.exact === true && string === recipe.title)
-				|| (options.exact === false
-					&& recipe.title.indexOf(string) !== -1))) {
 
-			results.push(recipe)
+
+		if (options.title) {
+			const title = recipe.title.toLowerCase()
+
+			if (options.exact && title === term) {
+				results.push(recipe)
+				continue
+			} else if (!options.exact && title.indexOf(term) !== -1) {
+				results.push(recipe)
+				continue
+			}
 		}
-		else if (options.ingredients === true) {
+		
+		if (options.ingredients) {
 			for (const ingredient of recipe.ingredients) {
-				if (ingredient.name.indexOf(string) !== -1) {
+				const name = ingredient.name.toLowerCase()
+
+				if (name.indexOf(term) !== -1) {
 					results.push(recipe)
-					break
+					continue
 				}
 			}
 		}

--- a/routes/data.js
+++ b/routes/data.js
@@ -17,10 +17,14 @@ const searchDB = (term, searchOptions, results, findFunc) =>
 	new Promise((resolve, _) => {
 		findFunc(term, searchOptions)
 			.then((dbResults) => {
+				// Filter dbResults in case of concurrent searchDB() calls
 				for (const dbResult of dbResults) {
-					const stored = (recipe) => recipe.title == dbResult.title
+					const isStored = (recipe) =>
+						recipe.title.toLowerCase()
+							=== dbResult.title.toLowerCase()
+
 					// Don't add to results if it's already there
-					if (!results.some(stored)) {
+					if (!results.some(isStored)) {
 						results.push(dbResult)
 					}
 				}


### PR DESCRIPTION
Add case-insensitivity to fileDB and filtering in routes/data.js by
converting search terms and item name strings to lowercase before
comparing when doing recipe searches.

Closes #57