### PR TITLE
Move recipes from profile to own tab

### DIFF
--- a/views/addRecipe.pug
+++ b/views/addRecipe.pug
@@ -1,6 +1,11 @@
-- const formType = 'add-recipe'
+.row.mb-3
+	.col-auto.mr-auto
+		a.btn.btn-outline-light(href='#' onclick='app.hideAddRecipePage()') <
 
-include ./recipeEdit
+
+- const formType = 'add-recipe'
+include ./parts/recipeEdit
+
 
 .row.justify-content-center.align-items-center
 	.col-auto: button#add-recipe-btn.btn-lg.btn-light(onclick='app.addRecipe()') Save

--- a/views/app.pug
+++ b/views/app.pug
@@ -18,11 +18,14 @@ html(lang='en')
 			#page-home.page
 				include ./parts/home
 
+			#page-my-recipes.page.d-none
+				include ./myRecipes
+
 			#page-pantry.page.d-none
 				include ./parts/pantry
 
 			#page-add-recipe.page.d-none
-				include ./parts/addRecipe
+				include ./addRecipe
 
 			#page-add-ingredient.page.d-none
 				include ./parts/addIngredient

--- a/views/myRecipes.pug
+++ b/views/myRecipes.pug
@@ -1,0 +1,9 @@
+.row.justify-content-end.mb-3: .col-auto
+	button.btn.btn-outline-light(onclick='app.showAddRecipePage()') +
+
+#profile-recipe-list
+
+#template-profile-recipe.d-none: .row
+	.col: a
+	.col-auto.pr-0: button.btn.btn-outline-danger X
+	.col-auto: button.btn.btn-outline-success.d-none Confirm

--- a/views/parts/navbar.pug
+++ b/views/parts/navbar.pug
@@ -1,6 +1,6 @@
 #navbar.row.mb-3: .col: nav.nav.nav-pills.nav-fill
 	a#navbar-home.main-nav.nav-item.nav-link.active(onclick='app.switchPage("home")' href='#') Home
 	a#navbar-pantry.main-nav.nav-item.nav-link.d-none(onclick='app.switchPage("pantry")' href='#') Pantry
-	a#navbar-add-recipe.main-nav.nav-item.nav-link.d-none(onclick='app.switchPage("add-recipe")' href='#') + Recipe
+	a#navbar-my-recipes.main-nav.nav-item.nav-link.d-none(onclick='app.switchPage("my-recipes")' href='#') My Recipes
 	a#navbar-add-ingredient.main-nav.nav-item.nav-link.d-none(onclick='app.switchPage("add-ingredient")' href='#') + Ingredient
 	a#navbar-profile.main-nav.nav-item.nav-link(onclick='app.switchPage("profile")' href='#') Profile

--- a/views/parts/recipeEdit.pug
+++ b/views/parts/recipeEdit.pug
@@ -1,3 +1,5 @@
+//- Depends on the pug that includes this file to define a var called formType
+
 .row.mb-3: .col: .input-group
 	.input-group-prepend: span.input-group-text Name
 	input.form-control(id=formType + '-form-name' type='text' autocomplete='off')

--- a/views/profile/view.pug
+++ b/views/profile/view.pug
@@ -2,13 +2,6 @@
 	h1#profile-name
 	p This is the profile!
 
-#profile-recipe-list
-
-#template-profile-recipe.d-none: .row
-	.col: a
-	.col-auto: button.btn.btn-outline-danger X
-	.col-auto.px-0: button.btn.btn-outline-success.d-none Confirm
-
 
 //- Password change
 #change-pass-btn.row.justify-content-center.mt-3: .col-auto

--- a/views/recipe.pug
+++ b/views/recipe.pug
@@ -1,8 +1,8 @@
-.row.mb-2
+.row.my-2
 	.col-auto.mr-auto
 		a#recipe-back-btn.btn.btn-secondary(href='#') <
 	.col-auto
-		a#recipe-save-btn.btn.btn-secondary(href='#' onclick='app.editRecipe()') Edit
+		a#recipe-edit-btn.btn.btn-secondary(href='#' onclick='app.editRecipe()') Edit
 
 .row: .col: h1#recipe-name
 


### PR DESCRIPTION
Move the recipes from a profile from the profile tab to its own tab,
replacing the "+ Recipe" tab. Recipes can still be added via this new
tab.

Closes #160