### PR TITLE
Add highlight to search result rows

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -5,3 +5,7 @@ h1 {
 a {
 	color: #02ddf9;
 }
+
+#searchResults .row:hover {
+	background-color: #222;
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -731,11 +731,10 @@
 			const $item = $('#template-search-result').clone()
 			$item.removeClass('d-none')
 
-			const id = getID()
-			$item.attr('id', id)
+			$item.attr('id', recipe._id)
+			$item.click(() => showRecipePage(recipe._id, false, 'home'))
 
-			const $link = $item.find('a')
-			$link.click(() => showRecipePage(recipe._id, false, 'home'))
+			const $link = $item.find('.col')
 			$link.html(recipe.name)
 			$('#searchResults').append($item)
 		})

--- a/views/parts/home.pug
+++ b/views/parts/home.pug
@@ -8,5 +8,4 @@
 
 	.mt-3#searchResults
 
-	#template-search-result.d-none: .row
-		.col: a
+	#template-search-result.row.py-1.d-none: .col


### PR DESCRIPTION
Highlight a row for the home page search results when mouse is hovered
over it.

Expand clickable area for home page search results row instead of just
the recipe name text.

Closes #179