### PR TITLE
Make unit in recipe form optional.

### DIFF
--- a/models/Recipe.js
+++ b/models/Recipe.js
@@ -12,8 +12,7 @@ const recipeIngredientSchema = new mongoose.Schema({
 	prep: { type: String, max: 20, min: 3, trim: true },
 	unit: {
 		type: String,
-		required: true,
-		enum: ['cup', 'floz', 'g', 'gal', 'kg', 'lb', 'liter', 'oz', 'pint',
+		enum: ['', 'cup', 'floz', 'g', 'gal', 'kg', 'lb', 'liter', 'oz', 'pint',
 			'quart', 'tbsp', 'tsp'],
 	},
 })

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -589,8 +589,9 @@
 		ingredients.forEach(ingredient => {
 			const prep = ingredient.prep ? ', ' + ingredient.prep : ''
 			const note = ingredient.note ? ' (' + ingredient.note + ')' : ''
-			const str = `${ingredient.amount} ${ingredient.unit} `
-				+ `${ingredient.name}${prep}${note}`
+			const unit = ingredient.unit ? ` ${ingredient.unit}` : ''
+			const str = `${ingredient.amount}${unit} ${ingredient.name}${prep}`
+				+ `${note}`
 
 			const $elem = $('<li></li>')
 			$elem.html(str)

--- a/views/recipeForm.pug
+++ b/views/recipeForm.pug
@@ -60,6 +60,7 @@ form
 			-
 				let _units3 = ['cup', 'floz', 'g', 'gal', 'kg', 'lb', 'liter', 'oz', 'pint', 'quart', 'tbsp', 'tsp']
 
+			option(value='') No unit
 			each unit in _units3
 				option(value=unit) #{unit}
 


### PR DESCRIPTION
In cases where a recipe calls for something like "1 egg", there is no
need to require users to measure the exact weight/volume of egg to use.