### PR TITLE
fix default recipe serving from 0 to 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6033,6 +6033,12 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+      "dev": true
+    },
     "minimist-options": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
@@ -6977,14 +6983,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
+        "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.1.tgz",
-          "integrity": "sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg=="
-        }
       }
     },
     "optionator": {

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -582,10 +582,7 @@ import * as util from './util.js'
 	// @param data{Object} The error data.
 	const onRecipeAddError = (data, _, _2) => {
 		resetRecipeFormInvalid()
-		const errs = data.responseJSON
-		if (errs.includes('name-exists')) {
-			util.showFormInvalid('#recipe-form-name', 'That name is taken')
-		}
+		console.trace(data)
 	}
 
 	// Handle when the recipe form is reset when adding a new recipe.

--- a/src/public/js/recipeForm.js
+++ b/src/public/js/recipeForm.js
@@ -2,6 +2,13 @@
 import $ from 'jquery/dist/jquery.min.js'
 import * as util from './util.js'
 
+// Provide a function for getting the servings to "default" the returned value
+// to 1 instead of 0.
+function getServings() {
+	const val = Number($('#recipe-form-servings').val())
+	return val === 0 ? 1 : val
+}
+
 // Add an ingredient form element to the recipe form.
 export const addIngredient = (ingredient) => {
 	const id = ingredient ? ingredient._id : util.generateID()
@@ -33,7 +40,7 @@ export const getRecipe = () => {
 	const recipe = {}
 	recipe._id = $('#recipe-form-name').attr('recipe-id')
 	recipe.name = $('#recipe-form-name').val()
-	recipe.servings = Number($('#recipe-form-servings').val())
+	recipe.servings = getServings()
 	recipe.ingredients = []
 
 	$('#recipe-form-ingredients').find('.ingredient').each((_, elem) => {
@@ -76,7 +83,7 @@ export const isValid = () => {
 		valid = false
 	}
 
-	// No recipe servings check
+	// No servings check
 
 	// Check > 0 ingredient
 	id = '#recipe-form-ingredients'

--- a/views/recipeForm.pug
+++ b/views/recipeForm.pug
@@ -14,7 +14,7 @@ form
 	.form-group.row.mb-3
 		label.col-form-label.col-auto.pr-2(for='recipe-form-servings') Servings
 		.col.pl-0: input#recipe-form-servings.form-control(type='number'
-			autocomplete='off' min='0' step='1' placeholder='1')
+			autocomplete='off' min='1' step='1' placeholder='1')
 
 	.form-row: .col
 		div Ingredients


### PR DESCRIPTION
A new recipe submitted with no input in the servings input would default
to a value of 0, which is not allowed. Instead of failing silently, the
default servings value was changed to 1 so that saves would succeed.

Closes #236 