### PR TITLE
patch: fix pantry add save status being cut off

### DIFF
--- a/views/pantryAdd.pug
+++ b/views/pantryAdd.pug
@@ -9,6 +9,7 @@ form: .form-row.mb-2: .col
 	#pantry-form-help.invalid-feedback.d-none
 
 .row.justify-content-center.align-items-center
-	.col-1: #pantry-save-status
 	.col-auto: button#pantry-submit-btn.btn-lg.btn-secondary(onclick='app.submitIngredient()') Submit
 	.col-auto: button#pantry-reset-btn.btn.btn-secondary(onclick='app.resetPantryForm()') Reset
+
+.row.justify-content-center.mt-3: .col-auto: #pantry-save-status


### PR DESCRIPTION
Pantry add save status was cut off by the submit button on mobile because
the column width was `1` to keep the save status and the buttons
centered and unmoving while the save status changed. Column width of `1`
however did not appear nicely on mobile and displaying the save status
caused the submit button to overlap the bleeding text.

Save status was moved to a separate row to allow it to expand as needed
without getting cut off.

Closes #247 